### PR TITLE
VC-6991 Fix column resizing on wrong column when grid scrolled to the…

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eclipsetrading/hypergrid",
-  "version": "4.10.0",
+  "version": "4.11.0",
   "description": "Canvas-based high-performance grid",
   "main": "dist/src/Hypergrid/index.js",
   "typings": "dist/src/Hypergrid/index.d.ts",

--- a/src/features/ColumnResizing.js
+++ b/src/features/ColumnResizing.js
@@ -105,11 +105,11 @@ var ColumnResizing = Feature.extend('ColumnResizing', {
 
             if (event.mousePoint.x <= 3) {
                 gridColumnIndex -= 1;
-                var vc = grid.renderer.visibleColumns[gridColumnIndex] ||
-                    grid.renderer.visibleColumns[gridColumnIndex - 1]; // get row number column if tree column undefined
-                if (vc) {
-                    this.dragColumn = vc.column;
-                    this.dragStartWidth = vc.width;
+                var ac = grid.behavior.getActiveColumn(gridColumnIndex)
+                    || grid.behavior.getActiveColumn(gridColumnIndex - 1); // get row number column if tree column undefined
+                if (ac) {
+                    this.dragColumn = ac;
+                    this.dragStartWidth = ac.properties.width;
                 } else {
                     return; // can't drag left-most column boundary
                 }
@@ -122,10 +122,10 @@ var ColumnResizing = Feature.extend('ColumnResizing', {
 
             if (this.dragColumn.properties.resizeColumnInPlace) {
                 gridColumnIndex += 1;
-                vc = grid.renderer.visibleColumns[gridColumnIndex] ||
-                    grid.renderer.visibleColumns[gridColumnIndex + 1]; // get first data column if tree column undefined;
-                if (vc) {
-                    this.nextColumn = vc.column;
+                ac = grid.behavior.getActiveColumn(gridColumnIndex)
+                    || grid.behavior.getActiveColumn(gridColumnIndex - 1); // get first data column if tree column undefined;
+                if (ac) {
+                    this.nextColumn = ac;
                     this.nextStartWidth = this.nextColumn.getWidth();
                 } else {
                     this.nextColumn = undefined;

--- a/src/features/ColumnResizing.js
+++ b/src/features/ColumnResizing.js
@@ -123,7 +123,7 @@ var ColumnResizing = Feature.extend('ColumnResizing', {
             if (this.dragColumn.properties.resizeColumnInPlace) {
                 gridColumnIndex += 1;
                 ac = grid.behavior.getActiveColumn(gridColumnIndex)
-                    || grid.behavior.getActiveColumn(gridColumnIndex - 1); // get first data column if tree column undefined;
+                    || grid.behavior.getActiveColumn(gridColumnIndex + 1); // get first data column if tree column undefined;
                 if (ac) {
                     this.nextColumn = ac;
                     this.nextStartWidth = this.nextColumn.getWidth();


### PR DESCRIPTION
To reproduce:
1. Grid must be scrolled along towards the right a bit
2. Cursor must click just to the right of the col header separation line