### PR TITLE
VC-10330 allow right click selection, and add in additional logic

### DIFF
--- a/src/features/CellSelection.js
+++ b/src/features/CellSelection.js
@@ -71,16 +71,16 @@ var CellSelection = Feature.extend('CellSelection', {
     handleMouseDown: function(grid, event) {
         var dx = event.gridCell.x,
             dy = event.dataCell.y,
-            isSelectable = grid.behavior.getCellProperty(event.dataCell.x, event.gridCell.y, 'cellSelection'),
-            lastSelection = grid.lastSelection;
+            isSelectable = grid.behavior.getCellProperty(event.dataCell.x, event.gridCell.y, 'cellSelection');
         var currentCell = { x: dx, y: dy };
         if (event.primitiveEvent.detail.isRightClick) {
+            var lastSelection = grid.lastSelection;
             const clickedWithinLastSelection = lastSelection && lastSelection.some((cell) => cell.x == currentCell.x && cell.y == currentCell.y);
             if (clickedWithinLastSelection) {
                 return;
             }
         }
-        
+
         if (isSelectable && event.isDataCell) {
             var dCell = grid.newPoint(dx, dy),
                 primEvent = event.primitiveEvent,

--- a/src/features/CellSelection.js
+++ b/src/features/CellSelection.js
@@ -71,9 +71,16 @@ var CellSelection = Feature.extend('CellSelection', {
     handleMouseDown: function(grid, event) {
         var dx = event.gridCell.x,
             dy = event.dataCell.y,
-            isSelectable = grid.behavior.getCellProperty(event.dataCell.x, event.gridCell.y, 'cellSelection');
+            isSelectable = grid.behavior.getCellProperty(event.dataCell.x, event.gridCell.y, 'cellSelection'),
+            lastSelection = grid.lastSelection;
+        var currentCell = { x: dx, y: dy };
+        const clickedWithinLastSelection = lastSelection && lastSelection.some((cell) => cell.x == currentCell.x && cell.y == currentCell.y);
 
-        if (isSelectable && event.isDataCell && !event.primitiveEvent.detail.isRightClick) {
+        if (clickedWithinLastSelection && event.primitiveEvent.detail.isRightClick) {
+            return;
+        }
+        
+        if (isSelectable && event.isDataCell) {
             var dCell = grid.newPoint(dx, dy),
                 primEvent = event.primitiveEvent,
                 keys = primEvent.detail.keys;

--- a/src/features/CellSelection.js
+++ b/src/features/CellSelection.js
@@ -74,10 +74,11 @@ var CellSelection = Feature.extend('CellSelection', {
             isSelectable = grid.behavior.getCellProperty(event.dataCell.x, event.gridCell.y, 'cellSelection'),
             lastSelection = grid.lastSelection;
         var currentCell = { x: dx, y: dy };
-        const clickedWithinLastSelection = lastSelection && lastSelection.some((cell) => cell.x == currentCell.x && cell.y == currentCell.y);
-
-        if (clickedWithinLastSelection && event.primitiveEvent.detail.isRightClick) {
-            return;
+        if (event.primitiveEvent.detail.isRightClick) {
+            const clickedWithinLastSelection = lastSelection && lastSelection.some((cell) => cell.x == currentCell.x && cell.y == currentCell.y);
+            if (clickedWithinLastSelection) {
+                return;
+            }
         }
         
         if (isSelectable && event.isDataCell) {


### PR DESCRIPTION
If the selection is a right-click and sits within another existing selection, persists it by not creating a new selection. 
If it's a left-click or a right-click outside existing selection, we will still create a new selection on the click