### PR TITLE
Remove version from package

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,6 @@
   "packages": {
     "": {
       "name": "@eclipsetrading/hypergrid",
-      "version": "4.25.0",
       "license": "MIT",
       "dependencies": {
         "@types/lodash": "4.14.168",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,5 @@
 {
   "name": "@eclipsetrading/hypergrid",
-  "version": "4.25.0",
   "description": "Canvas-based high-performance grid",
   "main": "dist/src/Hypergrid/index.js",
   "typings": "dist/src/Hypergrid/index.d.ts",

--- a/src/Base.js
+++ b/src/Base.js
@@ -11,25 +11,6 @@
  */
 var Base = require('extend-me').Base;
 
-Object.defineProperty(Base.prototype, 'version', {
-    enumerable: true,
-    writable: false, // read-only
-    configurable: false,
-    value: require('../package.json').version
-});
-
-Base.prototype.versionAtLeast = function(neededVersion) {
-    var neededParts = neededVersion.split('.').map(Number),
-        delta = this.version.split('.').map(function(part, i) { return Number(part) - neededParts[i]; });
-    return (
-        delta[0] > 0 ||
-        delta[0] === 0 && (
-            delta[1] > 0 ||
-            delta[1] === 0 && delta[2] >= 0
-        )
-    );
-};
-
 Base.prototype.deprecated = require('./lib/deprecated');
 Base.prototype.HypergridError = require('./lib/error');
 


### PR DESCRIPTION
Removes the version from the package and lockfile, since versioning is managed independently via the release process.

This removes confusion for developers whether to manually bump the version in `package.json`.

Using the same version in source code as the one for the release process would cause an error during the Publish step in GitHub Actions:
```
  npm --no-git-tag-version version 4.25.0
  shell: /usr/bin/bash -e {0}
  env:
    NPM_CONFIG_USERCONFIG: /home/runner/work/_temp/.npmrc
    NODE_AUTH_TOKEN: XXXXX-XXXXX-XXXXX-XXXXX
npm ERR! Version not changed, might want --allow-same-version
```