### PR TITLE
VC-11716 reset snapshot when error cell is rendered

### DIFF
--- a/src/renderer/by-cells.js
+++ b/src/renderer/by-cells.js
@@ -74,6 +74,7 @@ function paintCellsAsNeeded(gc) {
                 // VC-6892 Use _simplifiedPaintCell instead of _paintCell for performance reason
                 preferredWidth = Math.max(preferredWidth, this._paintCell(gc, pool[p]));
             } catch (e) {
+                cellEvent.snapshot[0] = undefined; // force repaint next time
                 this.renderErrorCell(e, gc, vc, pool[p].visibleRow);
             }
         }


### PR DESCRIPTION
In the hypergrid, there is a lazy rendering logic that only renders a cell if the cell's state matches the previously rendered snapshot.

A small bug exists in this logic: when an error cell is rendered, the snapshot is not updated. Consequently, if the error cell returns to its previous value, the hypergrid assumes the cell has not changed and will not re-render it. This situation causes the error cell to stay.